### PR TITLE
[DOM] MongoDB URI

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,7 +74,8 @@ app.get('*', (req, res) => {
 });
 
 //MongoDB connection string
-const uri = "mongodb+srv://rvramos:rvramos@trams-cluster-xmna9.mongodb.net/heroku_4gm4k4rf?retryWrites=true&w=majority"
+// const uri = "mongodb+srv://rvramos:rvramos@trams-cluster-xmna9.mongodb.net/heroku_4gm4k4rf?retryWrites=true&w=majority"
+const uri = "mongodb+srv://rvramos:rvramos@project-trams.xmna9.mongodb.net/trams-db?retryWrites=true&w=majority"
 mongoose.connect(process.env.MONGODB_URI || uri, { useNewUrlParser: true, useCreateIndex: true, useUnifiedTopology: true }).catch(error => handleError(error));
 
 const connection = mongoose.connection;


### PR DESCRIPTION
I only changed 1 line of code (server.js):

> changed the MongoDB URI (line 78) because we migrated (AGAIN :<) between clusters. The M2 paid cluster was migrated to a M0 free cluster; this is for local deployment since old cluster was shutdown.

> config vars URI of heroku were already fixed to new one, as well as connections to db from google sheets, webhooks, and globe text services